### PR TITLE
Return 418 status code for recognized failure codes

### DIFF
--- a/src/fetchExceptions.ts
+++ b/src/fetchExceptions.ts
@@ -1,0 +1,20 @@
+import {
+  Response as FetchResponse
+} from 'node-fetch'
+
+
+export const checkStatusCode = (response: FetchResponse): number | undefined => {
+  const { hostname } = new URL(response.url)
+  const code = exceptionMap.get(hostname)
+  if (code === response.status) {
+    console.log(`Returning status code 418 for ${hostname}`)
+    return 418
+  }
+}
+
+/**
+ * Known response codes to override with teapot response
+ */
+const exceptionMap = new Map([
+  ['api.binance.org', 403]
+])

--- a/src/indexCors.ts
+++ b/src/indexCors.ts
@@ -8,6 +8,7 @@ import fetch, {
   Response as FetchResponse
 } from 'node-fetch'
 import compression from 'compression'
+import { checkStatusCode } from './fetchExceptions'
 
 const mylog =  (...args: string[]): void => {
       const now = new Date().toISOString().slice(11, 23)
@@ -78,7 +79,8 @@ app.all('*', async (req: Request, res: Response) => {
       if (name === 'content-encoding') return
       res.header(name, value)
     })
-    res.status(response.status).send(bodyText)
+    const overrideStatusCode = checkStatusCode(response)
+    res.status(overrideStatusCode ?? response.status).send(bodyText)
   } catch (err) {
     let errMsg
     if (typeof err === 'object')    {


### PR DESCRIPTION
This will return the teapot code when we recognize that the cors proxy is not the correct path to complete the request. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205164464839301